### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install
 =======
 You can install the library via [NuGet].
 
-###Install-Package [SwipeListView]
+### Install-Package [SwipeListView]
 
 [NuGet]:http://nuget.org/
 [SwipeListView]:http://www.nuget.org/packages/SwipeListView


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
